### PR TITLE
Use gunzip role instead of bio perl to handle zipped files

### DIFF
--- a/lib/Bio/AssemblyImprovement/Util/FastqTools.pm
+++ b/lib/Bio/AssemblyImprovement/Util/FastqTools.pm
@@ -160,13 +160,11 @@ sub first_read_length {
     my ($self) = @_;
     my $fastq_obj;
 
-    if ( $self->input_filename =~ /\.fq$/ || $self->input_filename =~ /\.fastq$/  ) {
-    	$fastq_obj =  Bio::SeqIO->new( -file => $self->input_filename , -format => 'Fastq');
-    }
-    elsif ( $self->input_filename =~ /\.fq\.gz$/ || $self->input_filename =~ /\.fastq\.gz$/  ) {
-    	$fastq_obj =  Bio::SeqIO->new( -file => "gunzip -c " . $self->input_filename . " |" , -format => 'Fastq');
-    }
-    else {
+    my $fastq_file = $self->_gunzip_file_if_needed( $self->input_filename );
+
+    if ( $fastq_file =~ /\.fq$/ || $fastq_file =~ /\.fastq$/  ) {
+    	$fastq_obj =  Bio::SeqIO->new( -file => $fastq_file , -format => 'Fastq');
+    }else {
         die "File '$self->input_filename' not recognised as fastq. Needs to end in .fastq[.gz] or .fq[.gz]";
     }
 


### PR DESCRIPTION
Changed to using existing gunzip role instead of Bio Perl to handle zipped files.

In older versions of Bio/Root/IO.pm the following line was used to open files:

open ($fh,$file) || $self->throw("Could not open $file: $!");

In newer versions (on the farm and pcs5), the following line is used with $mode defaulting to "<" regardless of what is contained in $file.

open $fh, $mode, $file or $self->throw("Could not $action file '$file': $!");

So, for example, when we use:

$fastq_obj = Bio::SeqIO->new( -file => "gunzip -c myfile.gz |" , -format => 'Fastq');

This becomes:

open $fh, '<', 'gunzip -c myfile.gz |'

causing the following error:

Could not read file 'gunzip -c myfile.gz |': No such file or directory

I have submitted a report. 
