### PR TITLE
Do not die on iva qc error

### DIFF
--- a/lib/Bio/AssemblyImprovement/IvaQC/Main.pm
+++ b/lib/Bio/AssemblyImprovement/IvaQC/Main.pm
@@ -29,7 +29,7 @@ sub run {
     my $cwd = getcwd();
     my $iva_qc_dir = $self->working_directory."/iva_qc";
     if (! -d $iva_qc_dir) {
-		mkdir $iva_qc_dir or die "Could not create $iva_qc_dir";
+		mkdir $iva_qc_dir;
     } 
     chdir( $iva_qc_dir );
     
@@ -44,21 +44,20 @@ sub run {
             $self->prefix,
         )
     );
-	# run command
-    if (system($cmd)) {
-        die "Error running iva_qc with:\n$cmd";
-    }
-    # delete files and directories that were considered unnecessary
-    unlink($self->prefix.'.contig_placement.R',
-           $self->prefix.'.reads_mapped_to_assembly.bam',
-           $self->prefix.'.reads_mapped_to_assembly.bam.bai',
-           $self->prefix.'.reads_mapped_to_assembly.bam.flagstat',
-           $self->prefix.'.reads_mapped_to_ref.bam',
-           $self->prefix.'.reads_mapped_to_ref.bam.bai',
-           $self->prefix.'.reads_mapped_to_ref.bam.flagstat',    
-    );
-    rmtree($self->prefix.'.gage');
-    
+	
+    system($cmd); 
+
+	# delete files and directories that were considered unnecessary
+	unlink($self->prefix.'.contig_placement.R',
+		   $self->prefix.'.reads_mapped_to_assembly.bam',
+		   $self->prefix.'.reads_mapped_to_assembly.bam.bai',
+		   $self->prefix.'.reads_mapped_to_assembly.bam.flagstat',
+		   $self->prefix.'.reads_mapped_to_ref.bam',
+		   $self->prefix.'.reads_mapped_to_ref.bam.bai',
+		   $self->prefix.'.reads_mapped_to_ref.bam.flagstat',    
+	);
+	rmtree($self->prefix.'.gage');
+
     #change back to cwd
     chdir ($cwd);
 

--- a/t/IvaQC/Main.t
+++ b/t/IvaQC/Main.t
@@ -57,4 +57,18 @@ foreach my $dir(@dir_should_not_exist){
 }
 rmtree($current_dir.'/iva_qc');
 
+# Test iva qc error
+
+ok(my $obj = Bio::AssemblyImprovement::IvaQC::Main->new(
+    'db'      			  => $current_dir.'/t/data/database',
+    'forward_reads'       => $current_dir.'/t/data/forward.fastq',
+    'reverse_reads'       => $current_dir.'/t/data/reverse.fastq',
+    'assembly'			  => $current_dir.'/t/data/contigs.fa',
+    'iva_qc_exec'         => $current_dir.'/t/dummy_iva_qc_script_raise_error.py',
+    'prefix'              => $prefix,
+), 'initialize object with script returning error');
+
+$obj->run();
+
+
 done_testing();

--- a/t/IvaQC/Main.t
+++ b/t/IvaQC/Main.t
@@ -59,7 +59,7 @@ rmtree($current_dir.'/iva_qc');
 
 # Test iva qc error
 
-ok(my $obj = Bio::AssemblyImprovement::IvaQC::Main->new(
+ok(my $obj_error = Bio::AssemblyImprovement::IvaQC::Main->new(
     'db'      			  => $current_dir.'/t/data/database',
     'forward_reads'       => $current_dir.'/t/data/forward.fastq',
     'reverse_reads'       => $current_dir.'/t/data/reverse.fastq',
@@ -68,7 +68,7 @@ ok(my $obj = Bio::AssemblyImprovement::IvaQC::Main->new(
     'prefix'              => $prefix,
 ), 'initialize object with script returning error');
 
-$obj->run();
+$obj_error->run();
 
 
 done_testing();

--- a/t/dummy_iva_qc_script_raise_error.py
+++ b/t/dummy_iva_qc_script_raise_error.py
@@ -1,0 +1,7 @@
+#!/usr/bin/python
+
+import os
+
+class Error (Exception): pass
+
+raise Error ('Could not run iva_qc check - ignore error message')


### PR DESCRIPTION
Simple change to not die when iva_qc throws an error. Similar to the other tools run by assembly improvement, this now just runs the command and any errors thrown will be output on stderr. These will get logged in the .e files produced by the pipeline but won't stop the pipeline from carrying on.

Files changed:

lib/Bio/AssemblyImprovement/IvaQC/Main.pm
t/IvaQC/Main.t

