### PR TITLE
NDS circlator merge logs and quiver file tidy up

### DIFF
--- a/lib/Bio/AssemblyImprovement/Circlator/Main.pm
+++ b/lib/Bio/AssemblyImprovement/Circlator/Main.pm
@@ -59,17 +59,23 @@ sub run {
     	
     	my @iterative_merge_files = sort {$self->_get_number_in_filename($a) <=> $self->_get_number_in_filename($b)} glob("$temp_dir/04.merge.merge.iter.*.reads.log"); #cannot rely on glob's lexical sorting
     	
-    	my @log_files = ("$temp_dir/02.bam2reads.log",
-						 @iterative_merge_files,
-						"$temp_dir/04.merge.merge.iterations.log",
-						"$temp_dir/04.merge.merge.log",
-						"$temp_dir/04.merge.circularise_details.log",
-						"$temp_dir/04.merge.circularise.log",
-						"$temp_dir/05.clean.log",
-						"$temp_dir/06.fixstart.log");
+    	my @log_files_1 = ("$temp_dir/02.bam2reads.log",
+						   @iterative_merge_files,
+						   "$temp_dir/04.merge.merge.iterations.log",
+						  );
+						  
+		my $merge_summary = "$temp_dir/04.merge.merge.log"; # may not always be there
+						
+		my @log_files_2 = ("$temp_dir/04.merge.circularise_details.log",
+						   "$temp_dir/04.merge.circularise.log",
+						   "$temp_dir/05.clean.log",
+						   "$temp_dir/06.fixstart.log",
+						  );
     	
-    	system("cat ".join(" ", @log_files)." > ".$self->output_directory."/circlator.log") and die "Could not cat circlator log files to ".$self->output_directory."/circlator.log";
-    	system("rm -rf $temp_dir") and die "Could not delete $temp_dir"; 
+    	system("cat ".join(" ", @log_files_1)." > ".$self->output_directory."/circlator.log") and warn "Could not cat circlator log files to ".$self->output_directory."/circlator.log";
+    	system("cat $merge_summary >> ".$self->output_directory."/circlator.log") if (-e $merge_summary);
+    	system("cat ".join(" ", @log_files_2)." >> ".$self->output_directory."/circlator.log") and warn "Could not cat circlator log files to ".$self->output_directory."/circlator.log";
+    	system("rm -rf $temp_dir") and warn "Could not delete $temp_dir"; 
     }
     
     chdir ($cwd);

--- a/t/Circlator/Main.t
+++ b/t/Circlator/Main.t
@@ -36,4 +36,20 @@ is( @files - 2, 3, "File count OK"); # subtract 2 because readdir returns . and 
 
 rmtree('circularised');
 
+#--- test case when no merge.merge.log file is created ----#
+
+ok(my $obj_no_merge = Bio::AssemblyImprovement::Circlator::Main->new(
+    'assembly'      	  => $current_dir.'/t/data/contigs.fa',
+    'corrected_reads'     => $current_dir.'/t/data/shuffled.fastq',
+    'circlator_exec'      => $current_dir.'/t/dummy_circlator_script_no_merge_log',
+), 'initialize object');
+
+$obj_no_merge->run();
+
+my $expected_log_no_merge = read_file($current_dir.'/t/data/expected_circlator_no_merge.log');
+my $got_log_no_merge = read_file("circularised/circlator.log");
+is($got_log_no_merge, $expected_log_no_merge, "Logs concatenated in right order");
+
+rmtree('circularised');
+
 done_testing();

--- a/t/Quiver/Main.t
+++ b/t/Quiver/Main.t
@@ -16,7 +16,7 @@ my $current_dir = getcwd();
 ok(my $obj = Bio::AssemblyImprovement::Quiver::Main->new(
     'reference'      	  => $current_dir.'/t/data/contigs.fa',
     'bax_files'           => $current_dir.'/t/data/',
-    'pacbio_exec'         => $current_dir.'/t/dummy_quiver_script.pl',
+    'quiver_exec'         => $current_dir.'/t/dummy_quiver_script.pl',
 ), 'initialize object');
 
 $obj->run();

--- a/t/data/expected_circlator_no_merge.log
+++ b/t/data/expected_circlator_no_merge.log
@@ -1,0 +1,9 @@
+log_1
+log_2
+log_3
+log_4
+log_5
+log_7
+log_8
+log_9
+log_10

--- a/t/dummy_circlator_script_no_merge_log
+++ b/t/dummy_circlator_script_no_merge_log
@@ -1,0 +1,52 @@
+#!/usr/bin/env perl
+use Cwd;
+my $dir = "tmp_circularised";
+
+my @circlator_output_files         = ("00.info.txt",
+									  "00.input_assembly.fasta",
+									  "00.input_assembly.fasta.fai",
+									  "01.mapreads.bam",
+									  "01.mapreads.bam.bai",
+									  "02.bam2reads.log",
+									  "02.bam2reads.fasta",
+									  "04.merge.coords",
+									  "04.merge.fasta",
+									  "04.merge.merge.iterations.log",
+									  "04.merge.circularise_details.log",
+									  "04.merge.circularise.log",
+									  "04.merge.merge.iter.1.reads.log",
+									  "04.merge.merge.iter.2.reads.log",
+									  "04.merge.merge.iter.10.reads.log",
+									  "05.clean.contigs_to_keep",
+									  "05.clean.log",
+									  "05.clean.coords",
+									  "05.clean.fasta",
+									  "05.clean.remove_small.fa",
+									  "06.fixstart.fasta",
+									  "06.fixstart.contigs_to_not_change",
+									  "06.fixstart.log",
+									  "06.fixstart.fasta",
+									  "06.fixstart.ALL_FINISHED",
+									  );
+									  
+my @circlator_output_dir			= ("03.assemble");
+
+my $cwd = getcwd();
+system("mkdir $dir");
+chdir ("$dir");
+system("touch ".join(" ", @circlator_output_files));
+system("mkdir ".join(" ", @circlator_output_dir));
+
+# test logs
+system("echo log_1 > 02.bam2reads.log");
+system("echo log_2 > 04.merge.merge.iter.1.reads.log");
+system("echo log_3 > 04.merge.merge.iter.2.reads.log");
+system("echo log_4 > 04.merge.merge.iter.10.reads.log");
+system("echo log_5 > 04.merge.merge.iterations.log");
+system("echo log_7 > 04.merge.circularise_details.log");
+system("echo log_8 > 04.merge.circularise.log");
+system("echo log_9 > 05.clean.log");
+system("echo log_10 > 06.fixstart.log");
+
+chdir $cwd;
+


### PR DESCRIPTION
This PR does two things:

1) Quick fix for cases when circlator does not produce a file called merge.merge.log while still preserving the rest of the log files are concatenated in the right order
2) Tidy up of quiver's working directories